### PR TITLE
stdlib: don't use MSVC specific code on Clang

### DIFF
--- a/include/uacpi/platform/atomic.h
+++ b/include/uacpi/platform/atomic.h
@@ -19,7 +19,7 @@
 
 #include <uacpi/platform/compiler.h>
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
 
 #include <intrin.h>
 

--- a/include/uacpi/platform/compiler.h
+++ b/include/uacpi/platform/compiler.h
@@ -25,7 +25,7 @@
     #define UACPI_PACKED(decl) decl __attribute__((packed));
 #endif
 
-#ifdef __GNUC__
+#if defined(__GNUC__) || defined(__clang__)
     #define uacpi_unlikely(expr) __builtin_expect(!!(expr), 0)
     #define uacpi_likely(expr)   __builtin_expect(!!(expr), 1)
 

--- a/source/stdlib.c
+++ b/source/stdlib.c
@@ -595,7 +595,7 @@ void uacpi_memcpy_zerout(void *dst, const void *src,
 
 uacpi_u8 uacpi_bit_scan_forward(uacpi_u64 value)
 {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
     unsigned char ret;
     unsigned long index;
 
@@ -625,7 +625,7 @@ uacpi_u8 uacpi_bit_scan_forward(uacpi_u64 value)
 
 uacpi_u8 uacpi_bit_scan_backward(uacpi_u64 value)
 {
-#ifdef _MSC_VER
+#if defined(_MSC_VER) && !defined(__clang__)
     unsigned char ret;
     unsigned long index;
 


### PR DESCRIPTION
Clang supports the same GCC attributes/builtins even in MSVC mode, use those for better performance.