### PR TITLE
Add workarounds for OpenWatcom miscompilations

### DIFF
--- a/include/uacpi/internal/resources.h
+++ b/include/uacpi/internal/resources.h
@@ -249,18 +249,18 @@ struct uacpi_resource_convert_instruction {
     union {
         uacpi_u8 aml_offset;
         uacpi_u8 arg0;
-    };
+    } f1;
 
     union {
         uacpi_u8 native_offset;
         uacpi_u8 arg1;
-    };
+    } f2;
 
     union {
         uacpi_u8 imm;
         uacpi_u8 bit_index;
         uacpi_u8 arg2;
-    };
+    } f3;
 };
 
 struct uacpi_resource_spec {

--- a/source/opcodes.c
+++ b/source/opcodes.c
@@ -3,12 +3,12 @@
 #ifndef UACPI_BAREBONES_MODE
 
 #define UACPI_OP(opname, opcode, props, ...) \
-    { #opname, .decode_ops = __VA_ARGS__, .properties = props, .code = opcode },
+    { #opname, { .decode_ops = __VA_ARGS__ }, .properties = props, .code = opcode },
 
 #define UACPI_OUT_OF_LINE_OP(opname, opcode, out_of_line_buf, props) \
     {                                                                \
       .name = #opname,                                               \
-      .indirect_decode_ops = out_of_line_buf,                        \
+      { .indirect_decode_ops = out_of_line_buf },                    \
       .properties = props,                                           \
       .code = opcode,                                                \
     },


### PR DESCRIPTION
OpenWatcom miscompiles designated initializers that set fields within an anonymous union member (possibly open-watcom/open-watcom-v2#1365, though it manifests as a 'successful' compilation with incorrect data instead of a compiler error). This PR works around the issue in two ways:
1. Wrapping the union member initializer in braces. This explicitly acknowledges that the field to be initialized is within the anonymous union, which seems to fix the issue.
2. Naming the anonymous union member. This makes for somewhat uglier code, which is why the other workaround is preferred. However, that workaround would require very extensive changes in the resource conversion tables: the parameter order of almost every `OP()` macro invocation would need to be checked and corrected.

With these workarounds implemented, the full uACPI test suite passes when built using OpenWatcom (though this requires a work-in-progress test runner rewrite, as OpenWatcom does not support many of the modern C++ features the current runner uses).