### PR TITLE
Add support for compiling on OpenWatcom in C89 mode

### DIFF
--- a/include/uacpi/platform/compiler.h
+++ b/include/uacpi/platform/compiler.h
@@ -91,13 +91,12 @@
     #elif defined(__GNUC__)
         #define UACPI_POINTER_SIZE __SIZEOF_POINTER__
     #elif defined(__WATCOMC__)
-        #include <stdint.h>
-        #if UINTPTR_MAX == 0xFFFFFFFF
+        #ifdef __386__
             #define UACPI_POINTER_SIZE 4
-        #elif UINTPTR_MAX == 0xFFFF
+        #elif defined(__I86__)
             #error uACPI does not support 16-bit mode compilation
         #else
-            #error Unknown UINTPTR_MAX value
+            #error Unknown target architecture
         #endif
     #else
         #error Failed to detect pointer size

--- a/source/event.c
+++ b/source/event.c
@@ -972,13 +972,14 @@ void uacpi_events_match_post_dynamic_table_load(void)
     struct gpe_match_ctx match_ctx = {
         .post_dynamic_table_load = UACPI_TRUE,
     };
+    struct gpe_interrupt_ctx *irq_ctx;
 
     uacpi_namespace_write_unlock();
 
     if (uacpi_unlikely_error(uacpi_recursive_lock_acquire(&g_event_lock)))
         goto out;
 
-    struct gpe_interrupt_ctx *irq_ctx = g_gpe_interrupt_head;
+    irq_ctx = g_gpe_interrupt_head;
 
     while (irq_ctx) {
         match_ctx.block = irq_ctx->gpe_head;
@@ -2212,10 +2213,12 @@ void uacpi_deinitialize_events(void)
     }
 
     while (next_ctx) {
+        struct gpe_block *block, *next_block;
+
         ctx = next_ctx;
         next_ctx = ctx->next;
 
-        struct gpe_block *block, *next_block = ctx->gpe_head;
+        next_block = ctx->gpe_head;
         while (next_block) {
             block = next_block;
             next_block = block->next;

--- a/source/namespace.c
+++ b/source/namespace.c
@@ -450,10 +450,12 @@ uacpi_namespace_node *uacpi_namespace_node_find_sub_node(
     uacpi_object_name name
 )
 {
+    uacpi_namespace_node *node;
+
     if (parent == UACPI_NULL)
         parent = uacpi_namespace_root();
 
-    uacpi_namespace_node *node = parent->child;
+    node = parent->child;
 
     while (node) {
         if (node->name.id == name.id)

--- a/source/resources.c
+++ b/source/resources.c
@@ -132,9 +132,10 @@ static uacpi_size extra_size_for_native_irq_or_dma(
     const struct uacpi_resource_spec *spec, void *data, uacpi_size size
 )
 {
-    UACPI_UNUSED(size);
     uacpi_u16 mask;
     uacpi_u8 i, total_bits, num_bits = 0;
+
+    UACPI_UNUSED(size);
 
     if (spec->type == UACPI_AML_RESOURCE_IRQ) {
         struct acpi_resource_irq *irq = data;
@@ -230,8 +231,9 @@ static uacpi_size size_for_aml_vendor(
     const struct uacpi_resource_spec *spec, uacpi_resource *resource
 )
 {
-    UACPI_UNUSED(spec);
     uacpi_size size = resource->vendor.length;
+
+    UACPI_UNUSED(spec);
 
     if (size > 7 || resource->type == UACPI_RESOURCE_TYPE_VENDOR_LARGE) {
         size += aml_resource_kind_to_header_size[

--- a/source/stdlib.c
+++ b/source/stdlib.c
@@ -502,15 +502,14 @@ uacpi_i32 uacpi_vsnprintf(
 )
 {
     struct fmt_buf_state fb_state = { 0 };
-
-    fb_state.buffer = buffer;
-    fb_state.capacity = capacity;
-    fb_state.bytes_written = 0;
-
     uacpi_u64 value;
     const uacpi_char *next_conversion;
     uacpi_size next_offset;
     uacpi_char flag;
+
+    fb_state.buffer = buffer;
+    fb_state.capacity = capacity;
+    fb_state.bytes_written = 0;
 
     while (*fmt) {
         struct fmt_spec fm = {

--- a/source/uacpi.c
+++ b/source/uacpi.c
@@ -26,10 +26,11 @@ void uacpi_context_set_log_level(uacpi_log_level lvl)
 
 void uacpi_logger_initialize(void)
 {
+    static uacpi_bool version_printed = UACPI_FALSE;
+
     if (g_uacpi_rt_ctx.log_level == 0)
         uacpi_context_set_log_level(UACPI_DEFAULT_LOG_LEVEL);
 
-    static uacpi_bool version_printed = UACPI_FALSE;
     if (!version_printed) {
         version_printed = UACPI_TRUE;
         uacpi_info(


### PR DESCRIPTION
Previously, uACPI's support for OpenWatcom was limited to its C99 mode. This PR relaxes that requirement, allowing uACPI to be built in C89 mode as well.