### PR TITLE
Fix unreferenced symbol warnings on OpenWatcom

### DIFF
--- a/include/uacpi/platform/atomic.h
+++ b/include/uacpi/platform/atomic.h
@@ -249,7 +249,7 @@ static void uacpi_do_atomic_inc64_asm(volatile uint64_t *ptr, uint64_t *out);
     modify [ eax ebx ecx edx ]          \
     parm [ esi ] [ edi ]
 
-static uint64_t uacpi_do_atomic_inc64(volatile uint64_t *ptr) {
+static inline uint64_t uacpi_do_atomic_inc64(volatile uint64_t *ptr) {
     uint64_t value;
     uacpi_do_atomic_inc64_asm(ptr, &value);
     return value;
@@ -295,7 +295,7 @@ static void uacpi_do_atomic_dec64_asm(volatile uint64_t *ptr, uint64_t *out);
     modify [ eax ebx ecx edx ]          \
     parm [ esi ] [ edi ]
 
-static uint64_t uacpi_do_atomic_dec64(volatile uint64_t *ptr) {
+static inline uint64_t uacpi_do_atomic_dec64(volatile uint64_t *ptr) {
     uint64_t value;
     uacpi_do_atomic_dec64_asm(ptr, &value);
     return value;

--- a/include/uacpi/platform/compiler.h
+++ b/include/uacpi/platform/compiler.h
@@ -65,6 +65,23 @@
     #define UACPI_COMPILER_HAS_BUILTIN_MEMMOVE
     #define UACPI_COMPILER_HAS_BUILTIN_MEMSET
     #define UACPI_COMPILER_HAS_BUILTIN_MEMCMP
+#elif defined(__WATCOMC__)
+    #define uacpi_unlikely(expr) expr
+    #define uacpi_likely(expr) expr
+
+    /*
+     * The OpenWatcom documentation suggests this should be done using
+     * _Pragma("off (unreferenced)") and _Pragma("pop (unreferenced)"),
+     * but these pragmas appear to be no-ops. Use inline as the next best thing.
+     * Note that OpenWatcom accepts redundant modifiers without a warning,
+     * so UACPI_MAYBE_UNUSED inline still works.
+     */
+    #define UACPI_MAYBE_UNUSED inline
+
+    #define UACPI_NO_UNUSED_PARAMETER_WARNINGS_BEGIN
+    #define UACPI_NO_UNUSED_PARAMETER_WARNINGS_END
+
+    #define UACPI_PRINTF_DECL(fmt_idx, args_idx)
 #else
     #define uacpi_unlikely(expr) expr
     #define uacpi_likely(expr)   expr


### PR DESCRIPTION
Previously, compiling uACPI on OpenWatcom with a higher-than-default warning  level would generate unreferenced symbol warnings due to dynamic_array.h and helper functions in atomic.h. This PR fixes these by implementing `UACPI_MAYBE_UNUSED` for OpenWatcom and marking the helper functions as inline.

Closes #129.